### PR TITLE
Fix hatchling build configuration for uv sync

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,3 +12,6 @@ dependencies = [
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src"]


### PR DESCRIPTION
## Summary
- Fix `uv sync` build error by adding missing hatchling build configuration
- Add `[tool.hatch.build.targets.wheel]` section to `pyproject.toml` specifying `packages = ["src"]`
- Resolves ValueError about being unable to determine which files to ship in the wheel

## Problem
When running `uv sync`, users encounter a build error because hatchling cannot find package files. The project uses a `src/` directory layout but the build configuration was missing the required `packages` specification.

## Solution
Added the standard hatchling configuration for `src/` layout projects to tell the build system where to find source files.

## Test plan
- [x] Run `uv sync` successfully after the fix
- [x] Verify all dependencies install correctly
- [x] Confirm the package builds properly

🤖 Generated with [Claude Code](https://claude.ai/code)